### PR TITLE
Fix mysql query for deactivated users

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ This query retrieves all deactivated users in Mattermost.
 
 ```sql
 SELECT
-   COUNT (*)
+   COUNT(*)
 FROM
    Users
 WHERE
-   DeleteAt = 0;
+   DeleteAt != 0;
 ```
 
 ## Get Last Login Time


### PR DESCRIPTION
Minor typos:

- `DeleteAt` is the time at which the user was deactivated.
- MySQL does not like spaces after function names such as `count(*)`

Thank you for these queries!